### PR TITLE
Allow passing etags in DeploymentListOptions

### DIFF
--- a/github/repos_commits_test.go
+++ b/github/repos_commits_test.go
@@ -212,8 +212,8 @@ func TestRepositoriesService_GetCommitSHA1(t *testing.T) {
 		w.WriteHeader(http.StatusNotModified)
 	})
 
-	got, _, err = client.Repositories.GetCommitSHA1(context.Background(), "o", "r", "tag", sha1)
-	if err == nil {
+	got, resp, err := client.Repositories.GetCommitSHA1(context.Background(), "o", "r", "tag", sha1)
+	if err == nil || resp.StatusCode != http.StatusNotModified {
 		t.Errorf("Expected HTTP 304 response")
 	}
 

--- a/github/repos_deployments.go
+++ b/github/repos_deployments.go
@@ -46,6 +46,9 @@ type DeploymentRequest struct {
 // DeploymentsListOptions specifies the optional parameters to the
 // RepositoriesService.ListDeployments method.
 type DeploymentsListOptions struct {
+	// ETag to use in `If-None-Match` header field. (Helps reduce GitHub API rate limiting.)
+	ETag string `url:"-"`
+
 	// SHA of the Deployment.
 	SHA string `url:"sha,omitempty"`
 
@@ -74,6 +77,10 @@ func (s *RepositoriesService) ListDeployments(ctx context.Context, owner, repo s
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, nil, err
+	}
+
+	if opts.ETag != "" {
+		req.Header.Set("If-None-Match", opts.ETag)
 	}
 
 	var deployments []*Deployment


### PR DESCRIPTION
To avoid GitHub rate limiting, we allow callers to pass in an ETag value (to populate an `If-None-Match` header) when listing deployments